### PR TITLE
#28: Removed codes duplication in push and pull scripts

### DIFF
--- a/scripts/pull
+++ b/scripts/pull
@@ -29,12 +29,7 @@ fi
 if [ -e .git/modules ]; then
     subs=$(grep -c '^\[submodule' .gitmodules)
     title_it "Updating $(plural "${subs}" 'submodule') first..."
-    while true; do
-        bash_it "${GIT_BIN}" submodule update --remote && break
-        if [ -n "${GITTED_TESTING}" ]; then
-            exit 1
-        fi
-    done
+    retry_command "Updating submodules" "${GIT_BIN} submodule update --remote"
 fi
 
 inc=$(${GIT_BIN} status --porcelain | grep -c '^??' || true)
@@ -56,19 +51,7 @@ fi
 
 # shellcheck disable=SC2154
 if git ls-remote --exit-code origin "refs/heads/${master}" > /dev/null 2>&1; then
-    attempt=1
-    max=10
-    while true; do
-        title_it "Pulling from origin/${branch} (attempt no.${attempt}/${max})"
-        bash_it "${GIT_BIN}" pull origin "${branch}" && break
-        if [ -n "${GITTED_TESTING}" ]; then
-            exit 1
-        fi
-        attempt=$((attempt + 1))
-        if [ "${attempt}" -gt "${max}" ]; then
-            exit 1
-        fi
-    done
+    retry_command "Pulling from origin/${branch}" "${GIT_BIN} pull origin ${branch}"
 fi
 
 trap - EXIT

--- a/scripts/pull
+++ b/scripts/pull
@@ -27,7 +27,7 @@ if ! "${GIT_BIN}" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 
 fi
 
 if [ -e .git/modules ]; then
-    retry_command "Updating submodules" "${GIT_BIN} submodule update --remote"
+    retry_command "Updating submodules" "bash_it ${GIT_BIN} submodule update --remote"
 fi
 
 inc=$(${GIT_BIN} status --porcelain | grep -c '^??' || true)
@@ -49,7 +49,7 @@ fi
 
 # shellcheck disable=SC2154
 if git ls-remote --exit-code origin "refs/heads/${master}" > /dev/null 2>&1; then
-    retry_command "Pulling from origin/${branch}" "${GIT_BIN} pull origin ${branch}"
+    retry_command "Pulling from origin/${branch}" "bash_it ${GIT_BIN} pull origin ${branch}"
 fi
 
 trap - EXIT

--- a/scripts/pull
+++ b/scripts/pull
@@ -28,7 +28,6 @@ fi
 
 if [ -e .git/modules ]; then
     subs=$(grep -c '^\[submodule' .gitmodules)
-    title_it "Updating $(plural "${subs}" 'submodule') first..."
     retry_command "Updating submodules" "${GIT_BIN} submodule update --remote"
 fi
 

--- a/scripts/pull
+++ b/scripts/pull
@@ -27,7 +27,9 @@ if ! "${GIT_BIN}" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 
 fi
 
 if [ -e .git/modules ]; then
-    retry_command "Updating submodules" "bash_it ${GIT_BIN} submodule update --remote"
+    subs=$(grep -c '^\[submodule' .gitmodules)
+    title_it "Updating $(plural "${subs}" 'submodule') first..."
+    retry_it "Updating submodules" "bash_it ${GIT_BIN} submodule update --remote"
 fi
 
 inc=$(${GIT_BIN} status --porcelain | grep -c '^??' || true)
@@ -49,7 +51,7 @@ fi
 
 # shellcheck disable=SC2154
 if git ls-remote --exit-code origin "refs/heads/${master}" > /dev/null 2>&1; then
-    retry_command "Pulling from origin/${branch}" "bash_it ${GIT_BIN} pull origin ${branch}"
+    retry_it "Pulling from origin/${branch}" "bash_it ${GIT_BIN} pull origin ${branch}"
 fi
 
 trap - EXIT

--- a/scripts/pull
+++ b/scripts/pull
@@ -27,7 +27,6 @@ if ! "${GIT_BIN}" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 
 fi
 
 if [ -e .git/modules ]; then
-    subs=$(grep -c '^\[submodule' .gitmodules)
     retry_command "Updating submodules" "${GIT_BIN} submodule update --remote"
 fi
 

--- a/scripts/push
+++ b/scripts/push
@@ -15,4 +15,4 @@ set -e -o pipefail
 
 branch=$(git symbolic-ref HEAD --short)
 
-retry_command "Pushing to origin/${branch}" "bash_it ${GIT_BIN} push origin ${branch}"
+retry_it "Pushing to origin/${branch}" "bash_it ${GIT_BIN} push origin ${branch}"

--- a/scripts/push
+++ b/scripts/push
@@ -15,4 +15,4 @@ set -e -o pipefail
 
 branch=$(git symbolic-ref HEAD --short)
 
-retry_command "Pushing to origin/${branch}" "${GIT_BIN} push origin ${branch}"
+retry_command "Pushing to origin/${branch}" "bash_it ${GIT_BIN} push origin ${branch}"

--- a/scripts/push
+++ b/scripts/push
@@ -15,16 +15,4 @@ set -e -o pipefail
 
 branch=$(git symbolic-ref HEAD --short)
 
-attempt=1
-max=10
-while true; do
-    title_it "Pushing to origin/${branch} (attempt no.${attempt}/${max})"
-    bash_it "${GIT_BIN}" push origin "${branch}" && break
-    if [ -n "${GITTED_TESTING}" ]; then
-        exit 1
-    fi
-    attempt=$((attempt + 1))
-    if [ "${attempt}" -gt "${max}" ]; then
-        exit 1
-    fi
-done
+retry_command "Pushing to origin/${branch}" "${GIT_BIN} push origin ${branch}"

--- a/sub-scripts/commons.sh
+++ b/sub-scripts/commons.sh
@@ -31,7 +31,7 @@ function plural {
     fi
 }
 
-function retry_command {
+function retry_it {
     local message="$1"
     local cmd="$2"
     local max_attempts="${3:-10}"

--- a/sub-scripts/commons.sh
+++ b/sub-scripts/commons.sh
@@ -34,10 +34,10 @@ function plural {
 function retry_it {
     local message="$1"
     local cmd="$2"
-    local max_attempts="${3:-10}"
+    local max="${3:-10}"
     local attempt=1
-    while (( attempt <= max_attempts )); do
-        title_it "${message} (attempt no.${attempt}/${max_attempts})"
+    while (( attempt <= max )); do
+        title_it "${message} (attempt no.${attempt}/${max})"
         eval "$cmd" && return 0
         if [ -n "${GITTED_TESTING}" ]; then
             exit 1
@@ -45,7 +45,7 @@ function retry_it {
         attempt=$(( attempt + 1 ))
         sleep 1
     done
-    warn_it "Command failed after ${max_attempts} attempts: ${cmd}"
+    warn_it "Command failed after ${max} attempts: ${cmd}"
     exit 1
 }
 

--- a/sub-scripts/commons.sh
+++ b/sub-scripts/commons.sh
@@ -38,7 +38,7 @@ function retry_command {
     local attempt=1
     while (( attempt <= max_attempts )); do
         title_it "${message} (attempt no.${attempt}/${max_attempts})"
-        bash_it "$cmd" && return 0
+        eval "$cmd" && return 0
         if [ -n "${GITTED_TESTING}" ]; then
             exit 1
         fi

--- a/sub-scripts/commons.sh
+++ b/sub-scripts/commons.sh
@@ -31,6 +31,26 @@ function plural {
     fi
 }
 
+function retry_command {
+    local message="$1"
+    local cmd="$2"
+    local max_attempts="${3:-10}"
+    local attempt=1
+
+    while (( attempt <= max_attempts )); do
+        title_it "${message} (attempt no.${attempt}/${max_attempts})"
+        bash_it $cmd && return 0
+        if [ -n "${GITTED_TESTING}" ]; then
+            exit 1
+        fi
+        attempt=$(( attempt + 1 ))
+        sleep 1
+    done
+
+    echo "ERROR: Command failed after ${max_attempts} attempts: ${cmd}"
+    exit 1
+}
+
 base=$(dirname "$0")
 export base
 

--- a/sub-scripts/commons.sh
+++ b/sub-scripts/commons.sh
@@ -36,18 +36,16 @@ function retry_command {
     local cmd="$2"
     local max_attempts="${3:-10}"
     local attempt=1
-
     while (( attempt <= max_attempts )); do
         title_it "${message} (attempt no.${attempt}/${max_attempts})"
-        bash_it $cmd && return 0
+        bash_it "$cmd" && return 0
         if [ -n "${GITTED_TESTING}" ]; then
             exit 1
         fi
         attempt=$(( attempt + 1 ))
         sleep 1
     done
-
-    echo "ERROR: Command failed after ${max_attempts} attempts: ${cmd}"
+    warn_it "Command failed after ${max_attempts} attempts: ${cmd}"
     exit 1
 }
 


### PR DESCRIPTION
This is my first open source PR ;). Fixes issue #28

Created a new function `retry_command` in commons.sh that replaces the loops in the push and pull scripts:
- Takes a message, a command to execute, and the maximum number of retries if needed (default is 10)