### PR TITLE
Fix error when committing large diffs

### DIFF
--- a/scripts/commit
+++ b/scripts/commit
@@ -38,9 +38,9 @@ fi
 if [ -n "${OPENAI_API_KEY}" ]; then
     if "${GIT_BIN}" rev-parse --verify HEAD >/dev/null 2>&1; then
         if "${GIT_BIN}" rev-parse HEAD >/dev/null 2>&1; then
-            diff=$("${GIT_BIN}" diff HEAD | head -2000)
+            diff=$("${GIT_BIN}" diff HEAD)
         else
-            diff=$("${GIT_BIN}" diff | head -2000)
+            diff=$("${GIT_BIN}" diff)
         fi
     else
         diff=$("${GIT_BIN}" diff --staged)

--- a/tests.sh/commits-large-diff.sh
+++ b/tests.sh/commits-large-diff.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf repo
+git init repo --initial-branch=master
+cd repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch initial.txt
+git add initial.txt
+git commit --no-verify -am "initial commit"
+for i in {1..5000} ; do
+    printf "line %s\n" "${i}" >> large.txt
+done
+
+exit_code=0
+env "GITTED_TESTING=true" \
+    "OPENAI_API_KEY=fake-openai-api-key" \
+    "${base}/scripts/commit" "fake-commit-message" 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+cd .. || exit 1
+
+cd repo || exit 1
+test "${exit_code}" -eq 0
+git log | grep "fake-commit-message"


### PR DESCRIPTION
### Problem
The `commit` script fails with exit code 141 (SIGPIPE) when processing large diffs.

Problematic code:
```bash
diff=$("${GIT_BIN}" diff HEAD | head -2000)
diff=$("${GIT_BIN}" diff | head -2000)
```

`git diff` generates full diff → `head -2000` closes pipe → `git diff` writes to closed pipe → SIGPIPE.

### Solution
Removed `| head -2000` from `commit` script.

### Testing
Added `commits-large-diff.sh` test that reproduces the issue and confirms the fix.

Closes #34