### PR TITLE
Detect default branch

### DIFF
--- a/sub-scripts/commons.sh
+++ b/sub-scripts/commons.sh
@@ -52,7 +52,17 @@ function retry_it {
 base=$(dirname "$0")
 export base
 
-master=master
+branches="$(git branch --format='%(refname:short)')"
+if [ -z "${branches}" ]; then
+    master="$(git symbolic-ref --short HEAD 2>/dev/null || exit 1)"
+elif echo "$branches" | grep -qx 'master'; then
+    master=master
+elif echo "$branches" | grep -qx 'main'; then
+    master=main
+else
+    warn_it "Neither 'master' nor 'main' branch found."
+    exit 1
+fi
 export master
 
 if [ -z "${GIT_BIN}" ]; then

--- a/tests.sh/commit-fails-on-unknown-branch.sh
+++ b/tests.sh/commit-fails-on-unknown-branch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf repo
+git init repo --initial-branch=unknown
+cd repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch initial.txt
+git add initial.txt
+git commit --no-verify -am "initial commit"
+touch second.txt
+
+exit_code=0
+env "GITTED_TESTING=true" \
+    "${base}/scripts/commit" "fake-commit-message" 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+test "$exit_code" = 1
+cd .. || exit 1
+
+cd repo || exit 1
+grep "Neither 'master' nor 'main' branch found." "${tmp}/log.txt"

--- a/tests.sh/commits-on-main-branch.sh
+++ b/tests.sh/commits-on-main-branch.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf repo
+git init repo --initial-branch=main
+cd repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch initial.txt
+git add initial.txt
+git commit --no-verify -am "initial commit"
+touch second.txt
+
+env "GITTED_TESTING=true" \
+    "${base}/scripts/commit" "fake-commit-message" 2>&1 | tee "${tmp}/log.txt"
+cd .. || exit 1
+
+cd repo || exit 1
+git log | grep "fake-commit-message"


### PR DESCRIPTION
The new logic in `sub-scripts/commons.sh` works as follows:

1.  It checks if a branch named `master` exists.
2.  If not, it checks for a `main` branch.
3.  If neither `master` nor `main` is found, the script exits with an error message.

It also correctly handles newly initialized repositories that don't have any branches yet by using `git symbolic-ref`.

Closes #39 