### PR TITLE
Validate branch names to be positive integers

### DIFF
--- a/scripts/branch
+++ b/scripts/branch
@@ -8,8 +8,8 @@ set -e -o pipefail
 . "$(dirname "$0")/../sub-scripts/all.sh"
 
 name=$1
-if [ -z "${name}" ]; then
-    warn_it "Use it like this: 'branch 42', where 42 is the name of the branch and GitHub issue number"
+if ! [[ "${name}" =~ ^[1-9][0-9]*$ ]]; then
+    warn_it "Branch name must be a positive integer (GitHub issue number), got '${name}'"
     exit 1
 fi
 

--- a/tests.sh/branch-fails-if-name-has-letters.sh
+++ b/tests.sh/branch-fails-if-name-has-letters.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf repo
+git init repo
+cd repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch initial.txt
+git add initial.txt
+git commit --no-verify -am "initial commit"
+
+exit_code=0
+env "GITTED_TESTING=true" \
+    "${base}/scripts/branch" "feature-branch" 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+
+test "$exit_code" = 1
+grep "Branch name must be a positive integer (GitHub issue number), got 'feature-branch'" "${tmp}/log.txt"

--- a/tests.sh/branch-fails-if-name-is-empty.sh
+++ b/tests.sh/branch-fails-if-name-is-empty.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf repo
+git init repo
+cd repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch initial.txt
+git add initial.txt
+git commit --no-verify -am "initial commit"
+
+exit_code=0
+env "GITTED_TESTING=true" \
+    "${base}/scripts/branch" "" 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+
+test "$exit_code" = 1
+grep "Branch name must be a positive integer (GitHub issue number), got ''" "${tmp}/log.txt"

--- a/tests.sh/branch-fails-if-name-is-zero.sh
+++ b/tests.sh/branch-fails-if-name-is-zero.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf repo
+git init repo
+cd repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch initial.txt
+git add initial.txt
+git commit --no-verify -am "initial commit"
+
+exit_code=0
+env "GITTED_TESTING=true" \
+    "${base}/scripts/branch" 0 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+
+test "$exit_code" = 1
+grep "Branch name must be a positive integer (GitHub issue number), got '0'" "${tmp}/log.txt"


### PR DESCRIPTION
Enforces that branch names must be positive integers matching GitHub issue numbers. `branch` now fails with an error message when non-numeric names are provided.

Tests added for:
- Names with letters
- Empty names
- Zero as name

Closes #27