### PR TITLE
#38: retry push after pull --rebase when remote has new commits

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -23,7 +23,7 @@ jobs:
       GITTED_BATCH: true
     steps:
       - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           activate-environment: true

--- a/scripts/pull
+++ b/scripts/pull
@@ -19,15 +19,27 @@ fi
 
 if ! "${GIT_BIN}" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
     if git rev-parse --verify HEAD > /dev/null 2>&1; then
-        title_it "The upstream is not configured for the ${branch} branch, setting it to origin/${branch}"
         bash_it "${GIT_BIN}" fetch
-        bash_it "${GIT_BIN}" branch "--set-upstream-to=origin/${branch}" "${branch}"
+        if "${GIT_BIN}" ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+            title_it "The upstream is not configured for the ${branch} branch, setting it to origin/${branch}"
+            bash_it "${GIT_BIN}" branch "--set-upstream-to=origin/${branch}" "${branch}"
+        else
+            title_it "The ${branch} branch does not exist at origin yet, skipping upstream setup"
+        fi
     fi
 fi
 
 if [ -e .git/modules ]; then
     subs=$(grep -c '^\[submodule' .gitmodules)
     title_it "Updating $(plural "${subs}" 'submodule') first..."
+    bash_it "${GIT_BIN}" submodule deinit -f .
+    retry_it "Initializing submodules" "bash_it ${GIT_BIN} submodule update --init"
+    while read -r key path; do
+        name=${key#submodule.}
+        name=${name%.path}
+        bash_it "${GIT_BIN}" config "submodule.${name}.ignore" all
+        (cd "${path}" && bash_it "${GIT_BIN}" reset --hard)
+    done < <("${GIT_BIN}" config --file .gitmodules --get-regexp '^submodule\..*\.path$')
     retry_it "Updating submodules" "bash_it ${GIT_BIN} submodule update --remote"
 fi
 

--- a/scripts/push
+++ b/scripts/push
@@ -19,4 +19,19 @@ fi
 
 branch=$(git symbolic-ref HEAD --short)
 
-retry_it "Pushing to origin/${branch}" "bash_it ${GIT_BIN} push origin ${branch}"
+max=10
+attempt=1
+while (( attempt <= max )); do
+    title_it "Pushing to origin/${branch} (attempt no.${attempt}/${max})"
+    if bash_it "${GIT_BIN}" push origin "${branch}"; then
+        exit 0
+    fi
+    attempt=$(( attempt + 1 ))
+    if (( attempt > max )); then
+        break
+    fi
+    title_it "Push was rejected, rebasing on origin/${branch} before retrying"
+    bash_it "${GIT_BIN}" pull --rebase origin "${branch}"
+done
+
+fail_it "Failed to push to origin/${branch} after ${max} attempts"

--- a/sub-scripts/sanity.sh
+++ b/sub-scripts/sanity.sh
@@ -7,3 +7,6 @@ set -e -o pipefail
 if ! git rev-parse --git-dir > /dev/null 2>&1; then
     fail_it "Oops, this is not a Git repository"
 fi
+
+root=$(git rev-parse --show-toplevel)
+cd "${root}"

--- a/tests.sh/pushes-when-remote-has-new-commits.sh
+++ b/tests.sh/pushes-when-remote-has-new-commits.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf remote_repo
+git init --bare remote_repo --initial-branch=master
+
+rm -rf seed
+git clone "file://${tmp}/remote_repo" seed
+cd seed || exit 1
+git config user.email "seed@zerocracy.com"
+git config user.name "Seed Lebowski"
+echo 'seed' > seed.txt
+git add seed.txt
+git commit --no-verify -m "seed-commit"
+git push origin master
+cd .. || exit 1
+
+rm -rf racer
+git clone "file://${tmp}/remote_repo" racer
+cd racer || exit 1
+git config user.email "alice@zerocracy.com"
+git config user.name "Alice Lebowski"
+echo 'alice' > alice.txt
+git add alice.txt
+git commit --no-verify -m "fake-alice-msg"
+cd .. || exit 1
+
+rm -rf local_b
+git clone "file://${tmp}/remote_repo" local_b
+cd local_b || exit 1
+git config user.email "bob@zerocracy.com"
+git config user.name "Bob Lebowski"
+# Install a pre-push hook that lets Alice race ahead on first push
+# attempt only, so that Bob's first push is rejected with "fetch first".
+export RACER_DIR="${tmp}/racer"
+cat > .git/hooks/pre-push <<'HOOK'
+#!/bin/bash
+set -e
+marker="$(git rev-parse --git-dir)/race-triggered"
+if [ ! -e "${marker}" ]; then
+    touch "${marker}"
+    (cd "${RACER_DIR}" && git push origin master) >&2
+fi
+exit 0
+HOOK
+chmod +x .git/hooks/pre-push
+echo 'bob' > bob.txt
+
+env "GITTED_TESTING=true" "RACER_DIR=${RACER_DIR}" \
+    "${base}/scripts/push" fake-bob-msg 2>&1 | tee "${tmp}/log.txt"
+cd .. || exit 1
+
+cd local_b || exit 1
+git log | grep 'fake-bob-msg'
+git log | grep 'fake-alice-msg'
+cd .. || exit 1
+
+cd remote_repo || exit 1
+git log master | grep 'fake-bob-msg'
+git log master | grep 'fake-alice-msg'


### PR DESCRIPTION
@yegor256 — this PR closes #38 and also fixes the `master`-wide CI breakage that started with the merge of #98.

## What #38 is actually about

`scripts/push` already calls `scripts/pull` up-front, but between that pull and the final push another client can land a commit on the same ref (concurrent developer/CI/bot). `retry_it` then re-issues the identical `git push` without re-syncing local history, so every retry keeps hitting `! [rejected] master -> master (fetch first)` until the attempt budget is exhausted — exactly the failure mode reported in the issue.

## The fix

Replaced the single `retry_it "Pushing to origin/${branch}"` call with an explicit loop in `scripts/push` that:

1. runs `git push origin <branch>`;
2. on failure, rebases the local branch on top of `origin/<branch>` via `git pull --rebase origin <branch>`;
3. retries the push, up to the original 10-attempt budget.

A successful push `exit 0`s immediately; an unrecoverable error (e.g. real rebase conflict, network failure) still propagates out via `set -e`, so we never retry forever on something that can't be fixed by pulling.

## Why this PR also touches the workflow / sub-scripts

When I cloned `master` and ran `make`, three shell tests were already red (unrelated to #38):

- `commits-from-sub-directory.sh`
- `pulls-when-submodule-has-local-changes.sh`
- `pushes-to-empty-remote.sh`

And every CI `make` + `codecov` job on `master` and on every PR since 2026-04-19 has been red at step #1 `Set up job`. Digging in, all of this is the fallout of the automated merge of #98 (`chore(deps): replace astral-sh/setup-uv action with astral-sh/setup-uv v8`, commit 84d2ca1), which — despite its title — accidentally:

- reverted #60 (90c1731) — submodule `deinit -f . ` / `submodule update --init` / `reset --hard` in `scripts/pull`, required by `pulls-when-submodule-has-local-changes.sh`;
- reverted #69 (cdb756a) — the `ls-remote`-guarded branch in `scripts/pull` that skips upstream setup when the branch doesn't exist on `origin`, required by `pushes-to-empty-remote.sh`;
- reverted #76 (3283e17) — the `cd $(git rev-parse --show-toplevel)` line in `sub-scripts/sanity.sh`, required by `commits-from-sub-directory.sh`;
- swapped `astral-sh/setup-uv@v8.1.0` for `astral-sh/setup-uv@v8` in `.github/workflows/make.yml` and `.github/workflows/codecov.yml`. The `astral-sh/setup-uv` repo does **not** publish a floating `v8` tag (only `v8.0.0` and `v8.1.0`), which is why every `Set up job` step has been failing ever since.

I restored the three hunks to their pre-revert state and pinned the action back to `v8.1.0`. With those in place, `make -e` is green locally (20 pytest cases + 24 shell tests, including the new one) and CI on this PR is green across all 15 checks.

## Commit layout

1. `1617f30` Restore submodule handling and repo-root cd reverted by merge of #98 — build stabilization.
2. `dc4e812` #38: Reproduce 'push rejected when remote has new commits' — failing test only (fails without the fix).
3. `7ca5bc6` #38: pull --rebase and retry when push is rejected — the fix.
4. `7fc8991` Pin astral-sh/setup-uv to v8.1.0 to fix Set-up-job failure — unblocks CI.

## Test plan

- [x] `make -e` locally: 20 pytest cases + 24 shell tests, all green.
- [x] `shellcheck` and `bashate -i E006` clean on `scripts/*`, `sub-scripts/*.sh`, `tests.sh/*.sh`.
- [x] New test `pushes-when-remote-has-new-commits.sh` fails on commit 2 and passes on commit 3 (verified via `git stash` of the fix).
- [x] CI: all 15 checks green on this PR — `make` matrix (ubuntu-24.04 / macos-15 × 3.9 / 3.12), `shellcheck`, `bashate`, `actionlint`, `checkmake`, `xcop`, `markdown-lint`, `copyrights`, `reuse`, `typos`, `yamllint`, `pdd`.

Ready for your review and merge when you have a moment — happy to split the workflow-pin and sanity-cd restores into a separate PR first if you'd rather land the #98 fallout cleanup independently of the #38 fix.