### PR TITLE
#29: verify git presence and version in sanity.sh

### DIFF
--- a/src/gitted/diff2msg.py
+++ b/src/gitted/diff2msg.py
@@ -102,7 +102,7 @@ Don't even finish it with a dot, just give me a single sentence.
 def generate_commit_message(diff, msg=''):
     diff = prepare_diff(diff)
     if not diff.strip():
-        return 'No changes'
+        return msg if msg.strip() else 'No changes'
     if os.environ.get('GITTED_TESTING'):
         return msg
     prompt = prepare_prompt(diff, msg)

--- a/sub-scripts/all.sh
+++ b/sub-scripts/all.sh
@@ -9,6 +9,6 @@ scripts="$(dirname "$0")/../sub-scripts"
 # shellcheck disable=SC1091
 . "${scripts}/intro.sh"
 # shellcheck disable=SC1091
-. "${scripts}/commons.sh"
-# shellcheck disable=SC1091
 . "${scripts}/sanity.sh"
+# shellcheck disable=SC1091
+. "${scripts}/commons.sh"

--- a/sub-scripts/sanity.sh
+++ b/sub-scripts/sanity.sh
@@ -4,9 +4,36 @@
 
 set -e -o pipefail
 
-if ! git rev-parse --git-dir > /dev/null 2>&1; then
-    fail_it "Oops, this is not a Git repository"
+GITTED_GIT_MIN_MAJOR=2
+GITTED_GIT_MIN_MINOR=13
+
+function gitted_sanity_fail {
+    printf '\n⚠️ \e[38;5;160m%s\e[0m\n' "$@" >&2
+    exit 1
+}
+
+GIT_BIN="${GIT_BIN:-git}"
+
+if ! command -v "${GIT_BIN}" > /dev/null 2>&1; then
+    gitted_sanity_fail "Git is not installed: '${GIT_BIN}' command was not found in PATH"
 fi
 
-root=$(git rev-parse --show-toplevel)
+gitted_git_version_raw=$("${GIT_BIN}" --version 2>/dev/null | awk '{print $3}')
+if [ -z "${gitted_git_version_raw}" ]; then
+    gitted_sanity_fail "Failed to detect Git version (could not parse output of '${GIT_BIN} --version')"
+fi
+IFS='.' read -r gitted_git_major gitted_git_minor _ <<< "${gitted_git_version_raw}"
+if ! [[ "${gitted_git_major}" =~ ^[0-9]+$ ]] || ! [[ "${gitted_git_minor}" =~ ^[0-9]+$ ]]; then
+    gitted_sanity_fail "Failed to parse Git version '${gitted_git_version_raw}'"
+fi
+if (( gitted_git_major < GITTED_GIT_MIN_MAJOR )) || \
+    (( gitted_git_major == GITTED_GIT_MIN_MAJOR && gitted_git_minor < GITTED_GIT_MIN_MINOR )); then
+    gitted_sanity_fail "Git version ${gitted_git_version_raw} is too old; gitted requires Git ${GITTED_GIT_MIN_MAJOR}.${GITTED_GIT_MIN_MINOR}.0 or higher"
+fi
+
+if ! "${GIT_BIN}" rev-parse --git-dir > /dev/null 2>&1; then
+    gitted_sanity_fail "Oops, this is not a Git repository"
+fi
+
+root=$("${GIT_BIN}" rev-parse --show-toplevel)
 cd "${root}"

--- a/tests.sh/sanity-fails-when-git-is-not-installed.sh
+++ b/tests.sh/sanity-fails-when-git-is-not-installed.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf shadow
+mkdir shadow
+for tool in awk basename cat chmod cp cut dirname grep gpg head ls mkdir mktemp mv printf rm sed sort tail tee touch tr wc which; do
+    full=$(command -v "${tool}" || true)
+    if [ -n "${full}" ]; then
+        ln -sf "${full}" "shadow/${tool}"
+    fi
+done
+
+exit_code=0
+env -i \
+    HOME="${HOME}" \
+    "GITTED_TESTING=true" \
+    "GITTED_BATCH=true" \
+    "PATH=${tmp}/shadow" \
+    /bin/bash "${base}/scripts/branch" "1" 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+
+test "${exit_code}" = 1
+grep -q "'git' command was not found" "${tmp}/log.txt"

--- a/tests.sh/sanity-fails-when-git-is-too-old.sh
+++ b/tests.sh/sanity-fails-when-git-is-too-old.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf repo stubs
+git init repo --initial-branch=master
+cd repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch initial.txt
+git add initial.txt
+git commit --no-verify -am "initial commit"
+cd .. || exit 1
+
+mkdir stubs
+cat > stubs/git <<'EOF'
+#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "git version 1.5.0"
+    exit 0
+fi
+exec /usr/bin/env -i PATH="${ORIG_PATH}" git "$@"
+EOF
+chmod +x stubs/git
+
+cd repo || exit 1
+exit_code=0
+env "GITTED_TESTING=true" \
+    "ORIG_PATH=${PATH}" \
+    "PATH=${tmp}/stubs:${PATH}" \
+    "${base}/scripts/branch" "1" 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+
+test "${exit_code}" = 1
+grep -q 'too old' "${tmp}/log.txt"
+grep -q '1.5.0' "${tmp}/log.txt"

--- a/tests/test_diff2msg.py
+++ b/tests/test_diff2msg.py
@@ -233,6 +233,23 @@ class TestDiff2Msg:
         result = generate_commit_message('   ')
         assert result == 'No changes'
 
+    def test_falls_back_to_user_message_when_diff_is_empty(self):
+        result = generate_commit_message('', 'manual message')
+        assert result == 'manual message'
+
+    def test_falls_back_to_user_message_when_all_chunks_are_filtered(self):
+        header = (
+            "diff --git a/package-lock.json b/package-lock.json\n"
+            "index e69de29..d95f3ad 100644\n"
+            "--- a/package-lock.json\n"
+            "+++ b/package-lock.json\n"
+            "@@ -0,0 +1,600 @@\n"
+        )
+        body = "\n".join(f'+  "dep{i}": "^1.0.0",' for i in range(600))
+        diff = header + body + "\n"
+        result = generate_commit_message(diff, 'manual message')
+        assert result == 'manual message'
+
     def test_testing_mode(self, monkeypatch):
         monkeypatch.setenv('GITTED_TESTING', 'true')
         diff = """\


### PR DESCRIPTION
@yegor256

This PR closes #29 — `sub-scripts/sanity.sh` now verifies that `git` is on `PATH` and that its version is recent enough before any other gitted code attempts to use it.

## What changes

- **`sub-scripts/sanity.sh`** — adds an early `command -v "${GIT_BIN}"` presence check, parses `git --version`, and aborts with a friendly red-bold error if `git` is missing, unparseable, or older than `2.13`. The version floor is set by `git branch --format=%(refname:short)` in `commons.sh`, which was added in Git 2.13. The two existing `git rev-parse` calls switch to `"${GIT_BIN}"` for consistency.
- **`sub-scripts/all.sh`** — sources `sanity.sh` *before* `commons.sh`, so the friendly errors fire before `commons.sh` invokes `git branch` for branch detection. To make that order possible, `sanity.sh` no longer depends on `fail_it` from `commons.sh`; it uses a small local `gitted_sanity_fail` helper instead.
- **`tests.sh/sanity-fails-when-git-is-not-installed.sh`** — runs `scripts/branch` with `PATH` shadowed by a directory of symlinks containing every common UNIX tool *except* `git`, and asserts the script exits 1 with a `'git' command was not found` message.
- **`tests.sh/sanity-fails-when-git-is-too-old.sh`** — puts a stub `git` on `PATH` that reports `git version 1.5.0` and delegates everything else to the real binary, then asserts the script exits 1 with a `too old` message that names the offending version.

Both new tests fail on `master` and pass on this branch.

## Drive-by build fix (commits 1–2)

While reproducing the issue locally I noticed `make` was already failing on `master` because `commits-large-diff.sh` no longer found its expected commit message in the log. The cause is in `src/gitted/diff2msg.py`: after #103 started filtering out chunks larger than `MAX_CHUNK_LINES`, `generate_commit_message` returned the literal `'No changes'` even when the user had supplied a real commit message — silently discarding it. The first two commits add a unit-test reproduction in `tests/test_diff2msg.py` and then make `generate_commit_message` fall back to the user's message when the prepared diff is empty but the user gave one. `'No changes'` is still returned when there is genuinely nothing to commit. Without this, CI on this PR (and any other PR built on current `master`) would fail in a way unrelated to #29.

## Test plan

- [x] `make` passes locally with both new sanity tests and the previously-failing `commits-large-diff.sh` test
- [x] `shellcheck` clean across `sub-scripts/*.sh`, `scripts/*`, `tests.sh/*`
- [x] Verified each failing test fails on `master` and passes after the corresponding fix
- [ ] CI on `ubuntu-24.04` and `macos-15` for `make`/`shellcheck`/`bashate`/etc.

https://claude.ai/code/session_01XMkoaEvBNoTwCcLNTjTe2r
