### PR TITLE
#40: retry OpenAI call on APITimeoutError / APIConnectionError

### DIFF
--- a/src/gitted/diff2msg.py
+++ b/src/gitted/diff2msg.py
@@ -3,10 +3,13 @@
 
 import os
 import re
-from openai import OpenAI
+import time
+from openai import APIConnectionError, APITimeoutError, OpenAI
 
 
 MAX_CHUNK_LINES = 200
+MAX_OPENAI_ATTEMPTS = 4
+INITIAL_BACKOFF_SECONDS = 1.0
 
 
 def is_summarizable_chunk(chunk: str) -> bool:
@@ -107,11 +110,20 @@ def generate_commit_message(diff, msg=''):
         return msg
     prompt = prepare_prompt(diff, msg)
     client = OpenAI()
-    response = client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}],
-        max_tokens=100,
-        temperature=0.7
-    )
+    delay = INITIAL_BACKOFF_SECONDS
+    for attempt in range(1, MAX_OPENAI_ATTEMPTS + 1):
+        try:
+            response = client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=100,
+                temperature=0.7
+            )
+            break
+        except (APITimeoutError, APIConnectionError):
+            if attempt == MAX_OPENAI_ATTEMPTS:
+                raise
+            time.sleep(delay)
+            delay *= 2
     result = response.choices[0].message.content.strip()
     return result

--- a/tests/test_diff2msg.py
+++ b/tests/test_diff2msg.py
@@ -353,3 +353,152 @@ index 1234567..abcdefg 100644
         assert result == 'Fix bug in authentication'
         assert len(captured_messages) == 1
         assert 'fix auth' in captured_messages[0]
+
+    def test_retries_on_api_timeout_then_succeeds(self, monkeypatch):
+        import time
+        import httpx
+        from openai import APITimeoutError
+        monkeypatch.delenv('GITTED_TESTING', raising=False)
+        sleeps = []
+        monkeypatch.setattr(time, 'sleep', lambda s: sleeps.append(s))
+        attempts = {'count': 0}
+
+        class MockMessage:
+            def __init__(self):
+                self.content = 'Recovered after retry'
+
+        class MockChoice:
+            def __init__(self):
+                self.message = MockMessage()
+
+        class MockResponse:
+            def __init__(self):
+                self.choices = [MockChoice()]
+
+        class MockCompletions:
+            def create(self, **kwargs):
+                attempts['count'] += 1
+                if attempts['count'] < 3:
+                    raise APITimeoutError(
+                        request=httpx.Request(
+                            'POST',
+                            'https://api.openai.com/v1/chat/completions'
+                        )
+                    )
+                return MockResponse()
+
+        class MockChat:
+            def __init__(self):
+                self.completions = MockCompletions()
+
+        class MockClient:
+            def __init__(self):
+                self.chat = MockChat()
+
+        monkeypatch.setattr('gitted.diff2msg.OpenAI', MockClient)
+        diff = """\
+diff --git a/test.py b/test.py
+new file mode 100644
+index 0000000..1234567
+--- /dev/null
++++ b/test.py
+@@ -0,0 +1 @@
++x = 1
+"""
+        result = generate_commit_message(diff)
+        assert result == 'Recovered after retry'
+        assert attempts['count'] == 3
+        assert len(sleeps) == 2
+
+    def test_retries_on_api_connection_error_then_succeeds(self, monkeypatch):
+        import time
+        import httpx
+        from openai import APIConnectionError
+        monkeypatch.delenv('GITTED_TESTING', raising=False)
+        monkeypatch.setattr(time, 'sleep', lambda s: None)
+        attempts = {'count': 0}
+
+        class MockMessage:
+            def __init__(self):
+                self.content = 'Fixed connection'
+
+        class MockChoice:
+            def __init__(self):
+                self.message = MockMessage()
+
+        class MockResponse:
+            def __init__(self):
+                self.choices = [MockChoice()]
+
+        class MockCompletions:
+            def create(self, **kwargs):
+                attempts['count'] += 1
+                if attempts['count'] < 2:
+                    raise APIConnectionError(
+                        request=httpx.Request(
+                            'POST',
+                            'https://api.openai.com/v1/chat/completions'
+                        )
+                    )
+                return MockResponse()
+
+        class MockChat:
+            def __init__(self):
+                self.completions = MockCompletions()
+
+        class MockClient:
+            def __init__(self):
+                self.chat = MockChat()
+
+        monkeypatch.setattr('gitted.diff2msg.OpenAI', MockClient)
+        diff = """\
+diff --git a/x.py b/x.py
+index e69de29..d95f3ad 100644
+--- a/x.py
++++ b/x.py
+@@ -0,0 +1 @@
++y = 2
+"""
+        result = generate_commit_message(diff)
+        assert result == 'Fixed connection'
+        assert attempts['count'] == 2
+
+    def test_raises_after_max_retries_exhausted(self, monkeypatch):
+        import time
+        import httpx
+        import pytest
+        from openai import APITimeoutError
+        monkeypatch.delenv('GITTED_TESTING', raising=False)
+        monkeypatch.setattr(time, 'sleep', lambda s: None)
+        attempts = {'count': 0}
+
+        class MockCompletions:
+            def create(self, **kwargs):
+                attempts['count'] += 1
+                raise APITimeoutError(
+                    request=httpx.Request(
+                        'POST',
+                        'https://api.openai.com/v1/chat/completions'
+                    )
+                )
+
+        class MockChat:
+            def __init__(self):
+                self.completions = MockCompletions()
+
+        class MockClient:
+            def __init__(self):
+                self.chat = MockChat()
+
+        monkeypatch.setattr('gitted.diff2msg.OpenAI', MockClient)
+        diff = """\
+diff --git a/z.py b/z.py
+index e69de29..d95f3ad 100644
+--- a/z.py
++++ b/z.py
+@@ -0,0 +1 @@
++z = 3
+"""
+        with pytest.raises(APITimeoutError):
+            generate_commit_message(diff)
+        assert attempts['count'] >= 2


### PR DESCRIPTION
@yegor256 this fixes #40, where a transient TLS-handshake / network failure surfaces as `openai.APITimeoutError` and aborts `gitted` mid-run.

## What changed

`generate_commit_message` now wraps `client.chat.completions.create` in a small retry loop:

- up to `MAX_OPENAI_ATTEMPTS` (4) total attempts
- exponential backoff (1s, 2s, 4s) between attempts via `time.sleep`
- catches both `openai.APITimeoutError` and `openai.APIConnectionError` (the same class of transient network errors shown in the issue traceback)
- the original exception is re-raised once attempts are exhausted, so a permanent outage still surfaces to the caller instead of being swallowed

## Tests

Three regression tests in `tests/test_diff2msg.py` (all fail on master, all pass with this PR):

- `test_retries_on_api_timeout_then_succeeds` – two `APITimeoutError`s followed by success; verifies the result and the number of `time.sleep` calls.
- `test_retries_on_api_connection_error_then_succeeds` – same flow for `APIConnectionError`.
- `test_raises_after_max_retries_exhausted` – persistent timeouts; verifies the original `APITimeoutError` is re-raised after multiple attempts.

`time.sleep` is monkey-patched in the tests so they remain fast.

## CI

All 15 checks green: `actionlint`, `bashate`, `checkmake`, `copyrights`, `make (macos-15, 3.9 + 3.12)`, `make (ubuntu-24.04, 3.9 + 3.12)`, `markdown-lint`, `pdd`, `reuse`, `shellcheck`, `typos`, `xcop`, `yamllint`.