### PR TITLE
Fix #109: handle quoted filenames in diff chunks

### DIFF
--- a/src/gitted/diff2msg.py
+++ b/src/gitted/diff2msg.py
@@ -30,7 +30,11 @@ def is_summarizable_chunk(chunk: str) -> bool:
     if re.search(r'Binary files (.+) and (.+) differ', chunk, re.IGNORECASE):
         return False
     header = chunk.split('\n', 1)[0]
-    filenames = re.search(r'a/(.+) b/(.+)', header)
+    filenames = re.match(
+        r'^diff --git "a/(.+)" "b/(.+)"\s*$', header
+    ) or re.match(
+        r'^diff --git a/(.+) b/(.+)\s*$', header
+    )
     if not filenames:
         raise ValueError(
             "Invalid diff chunk format: " +

--- a/tests/test_diff2msg.py
+++ b/tests/test_diff2msg.py
@@ -107,6 +107,34 @@ index e69de29..d95f3ad 100644
         result = is_summarizable_chunk(diff)
         assert result
 
+    def test_handle_quoted_filenames_with_unicode(self):
+        diff = (
+            'diff --git "a/eo-runtime/src/main/java/org/eolang/'
+            'EOmalloc$EOof$EO\\317\\206.java" '
+            '"b/eo-runtime/src/main/java/org/eolang/'
+            'EOmalloc$EOof$EO\\317\\206.java"\n'
+            'index e69de29..d95f3ad 100644\n'
+            '--- a/file.java\n'
+            '+++ b/file.java\n'
+            '@@ -0,0 +1 @@\n'
+            '+content\n'
+        )
+        result = is_summarizable_chunk(diff)
+        assert result
+
+    def test_exclude_quoted_svg_filename(self):
+        diff = (
+            'diff --git "a/dir/icon-\\317\\206.svg" '
+            '"b/dir/icon-\\317\\206.svg"\n'
+            'index e69de29..ca56cec 100644\n'
+            '--- a/dir/icon.svg\n'
+            '+++ b/dir/icon.svg\n'
+            '@@ -0,0 +1 @@\n'
+            '+<svg/>\n'
+        )
+        result = is_summarizable_chunk(diff)
+        assert not result
+
     def test_raise_error_when_header_is_invalid(self):
         import pytest
         diff = """\


### PR DESCRIPTION
@yegor256 — this PR fixes #109.

**Reproduction.** When `git diff` produces a chunk header for a path containing non-ASCII bytes (or other special characters), Git C-quotes the path per `core.quotePath`, e.g.:

```
diff --git "a/eo-runtime/.../EOmalloc$EOof$EO\317\206.java" "b/eo-runtime/.../EOmalloc$EOof$EO\317\206.java"
```

The regex `r"a/(.+) b/(.+)"` in `is_summarizable_chunk` did not match the quoted form, so `prepare_diff` raised `ValueError: Invalid diff chunk format` and aborted commit-message generation for any repo with non-ASCII filenames.

**Fix.**
- `src/gitted/diff2msg.py`: anchor the header parse and accept both quoted and unquoted forms by trying `"a/..." "b/..."` first, then falling back to `a/... b/...`.
- `tests/test_diff2msg.py`: two regression tests — one for a quoted Unicode-bearing path (must remain summarizable), and one for a quoted `.svg` path (must still be excluded so the extension filter keeps working through quoting).

**Verification.**
- `make ruff flake8 mypy pytest` all green locally; 27 tests passed (the two new tests fail on `master` and pass with the fix).
- All 15 CI checks green on this PR.

Ready for merge.
