### PR TITLE
#46: create pull request after push

### DIFF
--- a/scripts/push
+++ b/scripts/push
@@ -7,6 +7,57 @@ set -e -o pipefail
 # shellcheck disable=SC1091
 . "$(dirname "$0")/../sub-scripts/all.sh"
 
+function github_slug {
+    local remote="$1"
+    remote="${remote%.git}"
+    if [[ "${remote}" =~ github.com[:/]([^/]+)/([^/]+)$ ]]; then
+        printf '%s/%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    fi
+}
+
+function maybe_create_pull_request {
+    local branch="$1"
+    if [ "${branch}" == "${master}" ]; then
+        return
+    fi
+    if ! command -v gh > /dev/null 2>&1; then
+        warn_it "GitHub CLI is not installed, skipping pull request creation"
+        return
+    fi
+    local origin
+    origin=$("${GIT_BIN}" remote get-url origin 2>/dev/null || true)
+    local head_repo
+    head_repo=$(github_slug "${origin}")
+    if [ -z "${head_repo}" ]; then
+        return
+    fi
+    local upstream
+    upstream=$("${GIT_BIN}" remote get-url upstream 2>/dev/null || true)
+    local base_repo
+    base_repo=$(github_slug "${upstream}")
+    if [ -z "${base_repo}" ]; then
+        base_repo="${head_repo}"
+    fi
+    local head_owner
+    head_owner="${head_repo%%/*}"
+    local head
+    head="${head_owner}:${branch}"
+    title_it "Checking for pull request ${head} in ${base_repo}"
+    local count
+    if ! count=$(gh pr list --repo "${base_repo}" --head "${head}" --state open --json number --jq length 2>/dev/null); then
+        warn_it "Failed to check pull requests with gh, skipping pull request creation"
+        return
+    fi
+    if [ "${count}" != '0' ]; then
+        title_it "Pull request already exists for ${head}"
+        return
+    fi
+    title_it "Creating pull request for ${head}"
+    if ! gh pr create --repo "${base_repo}" --head "${head}" --fill; then
+        warn_it "Failed to create pull request with gh"
+    fi
+}
+
 # shellcheck disable=SC2154
 "${base}/pull" "$*"
 
@@ -24,6 +75,7 @@ attempt=1
 while (( attempt <= max )); do
     title_it "Pushing to origin/${branch} (attempt no.${attempt}/${max})"
     if bash_it "${GIT_BIN}" push origin "${branch}"; then
+        maybe_create_pull_request "${branch}"
         exit 0
     fi
     attempt=$(( attempt + 1 ))

--- a/scripts/push
+++ b/scripts/push
@@ -17,6 +17,7 @@ function github_slug {
 
 function maybe_create_pull_request {
     local branch="$1"
+    # shellcheck disable=SC2154
     if [ "${branch}" == "${master}" ]; then
         return
     fi

--- a/tests.sh/pushes-creates-pull-request.sh
+++ b/tests.sh/pushes-creates-pull-request.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+real_git=$(command -v git)
+
+rm -rf bin upstream_repo remote_repo local_repo gh.log log.txt
+mkdir -p bin
+cat > bin/git <<GIT
+#!/bin/bash
+if [ "\$1" = "remote" ] && [ "\$2" = "get-url" ] && [ "\$3" = "origin" ]; then
+    echo "git@github.com:forker/gitted.git"
+    exit 0
+fi
+if [ "\$1" = "remote" ] && [ "\$2" = "get-url" ] && [ "\$3" = "upstream" ]; then
+    echo "https://github.com/yegor256/gitted.git"
+    exit 0
+fi
+exec "${real_git}" "\$@"
+GIT
+chmod +x bin/git
+
+cat > bin/gh <<'GH'
+#!/bin/bash
+printf '%s\n' "$*" >> "${GH_LOG}"
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+    echo 0
+    exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+    exit 0
+fi
+exit 1
+GH
+chmod +x bin/gh
+
+git init upstream_repo --initial-branch=master
+cd upstream_repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch readme.txt
+git add readme.txt
+git commit --no-verify -m init
+cd .. || exit 1
+
+git init --bare remote_repo --initial-branch=master
+git clone "file://${tmp}/remote_repo" local_repo
+cd local_repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+git remote add upstream "file://${tmp}/upstream_repo"
+git pull upstream master
+git checkout -b 46
+echo 'abc' > hello.txt
+
+env "GITTED_TESTING=true" "PATH=${tmp}/bin:${PATH}" "GIT_BIN=${tmp}/bin/git" "GH_LOG=${tmp}/gh.log" \
+    "${base}/scripts/push" fake-message 2>&1 | tee "${tmp}/log.txt"
+cd .. || exit 1
+
+grep 'pr list --repo yegor256/gitted --head forker:46 --state open --json number --jq length' "${tmp}/gh.log"
+grep 'pr create --repo yegor256/gitted --head forker:46 --fill' "${tmp}/gh.log"

--- a/tests.sh/pushes-skips-existing-pull-request.sh
+++ b/tests.sh/pushes-skips-existing-pull-request.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+real_git=$(command -v git)
+
+rm -rf bin upstream_repo remote_repo local_repo gh.log log.txt
+mkdir -p bin
+cat > bin/git <<GIT
+#!/bin/bash
+if [ "\$1" = "remote" ] && [ "\$2" = "get-url" ] && [ "\$3" = "origin" ]; then
+    echo "https://github.com/forker/gitted.git"
+    exit 0
+fi
+if [ "\$1" = "remote" ] && [ "\$2" = "get-url" ] && [ "\$3" = "upstream" ]; then
+    echo "https://github.com/yegor256/gitted.git"
+    exit 0
+fi
+exec "${real_git}" "\$@"
+GIT
+chmod +x bin/git
+
+cat > bin/gh <<'GH'
+#!/bin/bash
+printf '%s\n' "$*" >> "${GH_LOG}"
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+    echo 1
+    exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+    exit 10
+fi
+exit 1
+GH
+chmod +x bin/gh
+
+git init upstream_repo --initial-branch=master
+cd upstream_repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch readme.txt
+git add readme.txt
+git commit --no-verify -m init
+cd .. || exit 1
+
+git init --bare remote_repo --initial-branch=master
+git clone "file://${tmp}/remote_repo" local_repo
+cd local_repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+git remote add upstream "file://${tmp}/upstream_repo"
+git pull upstream master
+git checkout -b 46
+echo 'abc' > hello.txt
+
+env "GITTED_TESTING=true" "PATH=${tmp}/bin:${PATH}" "GIT_BIN=${tmp}/bin/git" "GH_LOG=${tmp}/gh.log" \
+    "${base}/scripts/push" fake-message 2>&1 | tee "${tmp}/log.txt"
+cd .. || exit 1
+
+grep 'pr list --repo yegor256/gitted --head forker:46 --state open --json number --jq length' "${tmp}/gh.log"
+if grep -q 'pr create' "${tmp}/gh.log"; then
+    echo "unexpected pull request creation"
+    exit 1
+fi
+grep 'Pull request already exists for forker:46' "${tmp}/log.txt"


### PR DESCRIPTION
Closes #46.

Changes:
- adds post-push GitHub PR creation for non-default branches when `gh` is available
- checks for an existing open PR from the pushed fork branch before creating a new one
- uses `upstream` as the base GitHub repo when present, otherwise falls back to `origin`
- keeps a successful `git push` non-fatal if `gh` is unavailable or a PR check/create call fails

Validation:
- `bash -n scripts/push tests.sh/pushes-creates-pull-request.sh tests.sh/pushes-skips-existing-pull-request.sh`
- `PATH=/tmp/gitted-realpath-bin:$PATH ./makes/one-test.sh tests.sh/pushes-creates-pull-request.sh target/logs/pushes-creates-pull-request.sh.txt`
- `PATH=/tmp/gitted-realpath-bin:$PATH ./makes/one-test.sh tests.sh/pushes-skips-existing-pull-request.sh target/logs/pushes-skips-existing-pull-request.sh.txt`
- `PATH=/tmp/gitted-realpath-bin:$PATH make clean all` (`pytest`: 30 passed; all shell tests passed)
- `git show --format= --check HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact`

Local note:
- This macOS host does not provide GNU `realpath`, so the validation commands put a temporary local `realpath` shim first in `PATH` for the existing shell test runner.
- The new PR-creation tests use fake `git` and `gh` wrappers; they do not create live GitHub PRs.