### PR TITLE
#41: read commit-message model from GITTED_MODEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ they will use ChatGPT to generate it, looking at the changes you've made.
 To make it work, define the `OPENAI_API_KEY` environment variable with the
 [OpenAI key].
 
+To use a different model, set `GITTED_MODEL` to its identifier; it defaults
+to `gpt-3.5-turbo`. To point at a different OpenAI-compatible endpoint
+(for example a local LLM such as Ollama or `llama.cpp` with the OpenAI
+shim, or any other proxy), set `OPENAI_BASE_URL` to the endpoint's URL;
+the `openai` Python client picks it up automatically.
+
 ## Conventions
 
 In order to work smoothly, you must respect a few conventions:

--- a/src/gitted/diff2msg.py
+++ b/src/gitted/diff2msg.py
@@ -10,6 +10,7 @@ from openai import APIConnectionError, APITimeoutError, OpenAI
 MAX_CHUNK_LINES = 200
 MAX_OPENAI_ATTEMPTS = 4
 INITIAL_BACKOFF_SECONDS = 1.0
+DEFAULT_MODEL = "gpt-3.5-turbo"
 
 
 def is_summarizable_chunk(chunk: str) -> bool:
@@ -114,11 +115,12 @@ def generate_commit_message(diff, msg=''):
         return msg
     prompt = prepare_prompt(diff, msg)
     client = OpenAI()
+    model = os.environ.get('GITTED_MODEL', DEFAULT_MODEL)
     delay = INITIAL_BACKOFF_SECONDS
     for attempt in range(1, MAX_OPENAI_ATTEMPTS + 1):
         try:
             response = client.chat.completions.create(
-                model="gpt-3.5-turbo",
+                model=model,
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=100,
                 temperature=0.7

--- a/tests/test_diff2msg.py
+++ b/tests/test_diff2msg.py
@@ -338,6 +338,48 @@ index 0000000..1234567
         result = generate_commit_message(diff)
         assert result == 'Add new feature'
 
+    def test_model_overridden_by_env(self, monkeypatch):
+        monkeypatch.delenv('GITTED_TESTING', raising=False)
+        monkeypatch.setenv('GITTED_MODEL', 'llama3:8b')
+        captured = {}
+
+        class MockMessage:
+            def __init__(self):
+                self.content = 'ok'
+
+        class MockChoice:
+            def __init__(self):
+                self.message = MockMessage()
+
+        class MockResponse:
+            def __init__(self):
+                self.choices = [MockChoice()]
+
+        class MockCompletions:
+            def create(self, **kwargs):
+                captured['model'] = kwargs['model']
+                return MockResponse()
+
+        class MockChat:
+            def __init__(self):
+                self.completions = MockCompletions()
+
+        class MockClient:
+            def __init__(self):
+                self.chat = MockChat()
+
+        monkeypatch.setattr('gitted.diff2msg.OpenAI', MockClient)
+        diff = """\
+diff --git a/file.py b/file.py
+index 0000000..1111111 100644
+--- a/file.py
++++ b/file.py
+@@ -0,0 +1 @@
++x = 1
+"""
+        generate_commit_message(diff)
+        assert captured['model'] == 'llama3:8b'
+
     def test_openai_call_with_message(self, monkeypatch):
         monkeypatch.delenv('GITTED_TESTING', raising=False)
         captured_messages = []


### PR DESCRIPTION
Closes #41.

The commit-message helper used to hard-code `gpt-3.5-turbo` against the OpenAI API, with no way to point at a different backend short of editing the source. This commit reads the model identifier from the `GITTED_MODEL` environment variable, falling back to `gpt-3.5-turbo` when the variable is unset, so an operator running a local LLM (Ollama, `llama.cpp`, or any OpenAI-compatible proxy) can name its model without touching the code. The endpoint itself is already controllable through `OPENAI_BASE_URL`, which the upstream `openai` client reads automatically; the README now documents both knobs.

The user-visible behaviour is unchanged when neither variable is set: the helper still calls `gpt-3.5-turbo` at `api.openai.com`. When `GITTED_MODEL` is set, that string is forwarded verbatim to the chat-completions call, and when `OPENAI_BASE_URL` is set, the client routes there.

Ran `uv run ruff check src/ tests/`, `uv run flake8 src/ tests/`, `uv run mypy src/ tests/`, and `uv run pytest tests/ -v --cov=src/gitted` locally: all four green, 31 tests passing (one new test covers the override path, the existing `test_openai_call` still pins the `gpt-3.5-turbo` default).
