### PR TITLE
#121: cap branch push retries via retry_it

### DIFF
--- a/scripts/branch
+++ b/scripts/branch
@@ -30,13 +30,7 @@ bash_it "${GIT_BIN}" status
 title_it "Checking out the origin/${name} branch"
 bash_it "${GIT_BIN}" checkout -b "${name}"
 
-while true; do
-    title_it "Pushing to the origin/${name} branch"
-    bash_it "${GIT_BIN}" push origin "${name}" && break
-    if [ -n "${GITTED_TESTING}" ]; then
-        exit 1
-    fi
-done
+retry_it "Pushing to the origin/${name} branch" "bash_it ${GIT_BIN} push origin ${name}"
 
 title_it "Setting the upstream of the origin/${name} branch"
 bash_it "${GIT_BIN}" branch "--set-upstream-to=origin/${name}" "${name}"

--- a/tests.sh/branch-fails-when-push-rejected.sh
+++ b/tests.sh/branch-fails-when-push-rejected.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf there
+git init --bare there --initial-branch=master
+
+rm -rf seed
+git clone "file://${tmp}/there" seed
+cd seed || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+touch hello.txt
+git add hello.txt
+git commit --no-verify -am init
+git push origin master
+cd .. || exit 1
+
+cat > there/hooks/pre-receive <<'HOOK'
+#!/bin/sh
+echo "pre-receive hook rejects push" >&2
+exit 1
+HOOK
+chmod +x there/hooks/pre-receive
+
+rm -rf here
+git clone "file://${tmp}/there" here
+cd here || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+
+exit_code=0
+env "GITTED_TESTING=true" \
+    "${base}/scripts/branch" 42 2>&1 | tee "${tmp}/log.txt" || exit_code=$?
+
+test "${exit_code}" = 1
+grep -q "Pushing to the origin/42 branch" "${tmp}/log.txt"


### PR DESCRIPTION
Closes #121.

The push retry in `scripts/branch` was a `while true` loop that re-ran `git push origin <name>` on every failure with no attempt cap and no delay, so a server that kept rejecting the new branch (pre-receive hook, permission problem, transient network refusal) pinned the script at 100% CPU until the user killed it. In testing mode the loop exited after the first attempt, but in production it never did.

This swaps that loop for a single `retry_it` call, which is the helper that the other scripts already use for the same shape of work. The behavior is now ten attempts, one-second sleep between them, and a `Command failed after 10 attempts` exit on the last failure; `GITTED_TESTING=true` still short-circuits after the first attempt, matching the previous test contract.

A new shell test, `tests.sh/branch-fails-when-push-rejected.sh`, stands up a bare remote with a pre-receive hook that rejects every push and asserts that `scripts/branch 42` exits non-zero and logs the push attempt. Locally, `GIT_CONFIG_GLOBAL=/dev/null GITTED_TESTING=true GITTED_BATCH=true make -e` passes ruff, flake8, mypy, pytest (31 passed, 98% coverage), and every shell test in `tests.sh/`.
