### PR TITLE
fix(pull): skip pull when branch does not exist at origin

### DIFF
--- a/scripts/pull
+++ b/scripts/pull
@@ -49,7 +49,6 @@ if [ ! "${inc}" == '0' ]; then
     bash_it "${GIT_BIN}" add .
 fi
 
-# shellcheck disable=SC2154
 if git ls-remote --exit-code origin "refs/heads/${branch}" > /dev/null 2>&1; then
     retry_it "Pulling from origin/${branch}" "bash_it ${GIT_BIN} pull --autostash origin ${branch}"
 else
@@ -57,6 +56,7 @@ else
 fi
 
 if ${GIT_BIN} remote | cut -f1 -d ' ' | grep upstream; then
+    # shellcheck disable=SC2154
     if [ "${branch}" != "${master}" ]; then
         title_it "Checking out the origin/${master} branch"
         bash_it "${GIT_BIN}" checkout "${master}"

--- a/scripts/pull
+++ b/scripts/pull
@@ -50,8 +50,10 @@ if [ ! "${inc}" == '0' ]; then
 fi
 
 # shellcheck disable=SC2154
-if git ls-remote --exit-code origin "refs/heads/${master}" > /dev/null 2>&1; then
+if git ls-remote --exit-code origin "refs/heads/${branch}" > /dev/null 2>&1; then
     retry_it "Pulling from origin/${branch}" "bash_it ${GIT_BIN} pull --autostash origin ${branch}"
+else
+    title_it "The ${branch} branch does not exist at origin yet, skipping pull"
 fi
 
 if ${GIT_BIN} remote | cut -f1 -d ' ' | grep upstream; then

--- a/tests.sh/pushes-to-non-existing-branch.sh
+++ b/tests.sh/pushes-to-non-existing-branch.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+tmp=$(pwd)
+base=$(realpath "$(dirname "$0")/..")
+
+rm -rf remote_repo
+git init --bare remote_repo --initial-branch=master
+
+rm -rf seed_repo
+git clone "file://${tmp}/remote_repo" seed_repo
+cd seed_repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+echo 'seed' > seed.txt
+git add seed.txt
+git commit --no-verify -m "seed-master-msg"
+git push origin master
+cd .. || exit 1
+
+rm -rf local_repo
+git clone "file://${tmp}/remote_repo" local_repo
+cd local_repo || exit 1
+git config user.email "jeff@zerocracy.com"
+git config user.name "Jeff Lebowski"
+git checkout -b 813
+echo 'abc' > hello.txt
+git add hello.txt
+git commit --no-verify -m "fake-new-branch-msg"
+
+env "GITTED_TESTING=true" \
+    "${base}/scripts/push" 2>&1 | tee "${tmp}/log.txt"
+cd .. || exit 1
+
+grep 'does not exist at origin yet, skipping pull' "${tmp}/log.txt"
+
+cd remote_repo || exit 1
+git log 813 | grep 'fake-new-branch-msg'


### PR DESCRIPTION
Closes #130.

## Problem

When pushing to a branch that does not yet exist at `origin`, the pull step failed:

```
👉 Pulling from origin/813 (attempt no.8/10)...
+ git pull --autostash origin 813
fatal: couldn't find remote ref 813
```

In `scripts/pull`, the guard before pulling checked whether the **master** branch existed at origin:

```bash
if git ls-remote --exit-code origin "refs/heads/${master}" > /dev/null 2>&1; then
    retry_it "Pulling from origin/${branch}" "bash_it ${GIT_BIN} pull --autostash origin ${branch}"
fi
```

But the pull targets `${branch}`, not `${master}`. So when a new branch is being pushed while `master` already exists at origin, the guard passed and the subsequent pull failed.

## Fix

Check for the existence of the **current branch** at origin instead, and emit a clear message when it is missing so the push proceeds without attempting a pull.

## Tests

Added `tests.sh/pushes-to-non-existing-branch.sh`, which reproduces the issue (a new branch pushed while `master` exists at origin). Verified it fails with the exact error from the issue before the fix and passes after. Existing pull/push tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHUe4wrS4BrCkRtfTbku4P)_