### PR TITLE
#123: align Python classifiers with requires-python and CI matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,11 @@ classifiers = [
     "Topic :: Software Development :: Version Control :: Git",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "openai>=1.82.0",


### PR DESCRIPTION
The `pyproject.toml` classifiers contradicted `requires-python = ">=3.9"` by advertising Python 3.6, 3.7, and 3.8, which pip cannot install on this project, while omitting 3.11, 3.12, and 3.13 even though `.github/workflows/make.yml` exercises 3.12 on every push. The mismatch misled PyPI browsers and the CI matrix at the same time. Closes #123.

The classifiers block now drops the three unsupported lower entries and lists 3.9 through 3.13. `requires-python` is unchanged, so the wheel still installs on the same set of interpreters.

Ran `uv build --no-build-logs` against the edited tree and got both the sdist and the wheel without warnings; `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` parsed the file cleanly.

Closes #123