### PR TITLE
Fix Python source wildcard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -e -o pipefail -c
 
-PYS = $(wildcard src/**.py)
+PYS = $(wildcard src/gitted/*.py)
 TESTS = $(subst tests.sh/,,$(wildcard tests.sh/*.sh))
 RESULTS = $(addprefix target/logs/,$(addsuffix .txt,$(TESTS)))
 SCRIPTS = $(wildcard scripts/*)


### PR DESCRIPTION
Fixes #135.

The Makefile used `$(wildcard src/**.py)`, which doesn't recurse with GNU make and leaves `PYS` empty for the current `src/gitted/*.py` layout. This changes the pattern to the actual package directory so the lint/type/test prerequisites include the Python sources.

Checked locally:
- `PYTHONPATH=src python -m pytest tests/ -v` -> 31 passed
- `PYTHONPATH=src python -m flake8 src/ tests/` -> passed
- `PYTHONPATH=src python -m mypy src/ tests/` -> passed

Note: `make`/`uv` are not installed in my local shell, so I ran the underlying checks directly.