### PR TITLE
Pin workflow action versions

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: ludeeus/action-shellcheck@master
+      - uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@v1.3


### PR DESCRIPTION
Fixes #134.

The three workflows referenced third-party actions through their moving `master` branches. This pins the shellcheck and xcop actions to their current release tags and pins pdd-action to its current `master` commit because it publishes no release tags.

Checked locally:
- every `.github/workflows/*.yml` file parses with Ruby's YAML parser
- each pinned tag or commit resolves through the GitHub API
- `git diff --check` passed